### PR TITLE
Implement summoner ID fetching function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = { version= "0.11.11", features = ["blocking"]} 
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 
 [dependencies]
 reqwest = { version= "0.11.11", features = ["blocking"]} 
-serde_json = "1.0"
 serenity = { version = "0.11.2", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,33 @@
+pub mod fetcher {
+    extern crate reqwest;
+    use reqwest::Client;
+    use std::env;
+
+    pub async fn fetch_summoner_id(summoner_name: &str) -> String {
+        let token = env::var("RIOT_API_TOKEN").expect("Expected a token in the environment");
+        let mut uri =
+            "https://euw1.api.riotgames.com/tft/summoner/v1/summoners/by-name/".to_string();
+        uri.push_str(summoner_name);
+        let client = Client::new();
+
+        let response = client
+            .get(uri)
+            .header("Accept-Language", "en-GB,en;q=0.5")
+            .header(
+                "Accept-Charset",
+                "application/x-www-form-urlencoded; charset=UTF-8",
+            )
+            .header("X-Riot-Token", &token)
+            .send()
+            .await;
+
+        let resp = response.ok();
+
+        resp.unwrap().text().await.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fetcher::fetch_summoner_id;
+}


### PR DESCRIPTION
Implements `fetch_summoner_id()`, which calls out to the Riot API with a summoner name as a parameter and fetches summoner data(IDs). 